### PR TITLE
Fix bad UTF8 in blog feeds

### DIFF
--- a/views/sections/blog.php
+++ b/views/sections/blog.php
@@ -1,6 +1,9 @@
 <ul>
 <?php
 $c = 0;
+if (function_exists('mb_substitute_character')) {
+	mb_substitute_character(0xFFFD);
+}
 foreach($items as $item) {
 	if($c > $limit) {
 		break;
@@ -9,6 +12,7 @@ foreach($items as $item) {
 	if ($description) {
 		if (function_exists('mb_substr')) {
 			$tooltip = mb_substr(strip_tags($description,'<br>'),0,200, 'UTF-8')."...";
+			mb_convert_encoding($tooltip, 'UTF-8', 'UTF-8');
 		} else {
 			$tooltip = substr(strip_tags($description,'<br>'),0,200)."...";
 		}
@@ -17,6 +21,9 @@ foreach($items as $item) {
 	}
 	$href = $item->url;
 	$title = $item->title;
+	if (function_exists('mb_convert_encoding')) {
+		mb_convert_encoding($title, 'UTF-8', 'UTF-8');
+	}
 	print "<li><small><a data-toggle='tooltip' title='$tooltip' href='$href' target='_blank'>$title</a></small></li>\n";
 	$c++;
 }


### PR DESCRIPTION
I was installing freepbx today and the dashboard wouldn't load.

It seems that one of the entries inthe RSS feed had invalid UTF8 characters. This was causing 

http://pabx/admin/ajax.php?command=getcontent&module=dashboard&rawname=Blogs&section=0

to return no content.

I assume something, either PHP7 or Symphony? Is droping the content as a precuation.

This patch isn't quite compete as it only handles the case where ```mb_convert_encoding``` is available.