### PR TITLE
Make the dashboard statistics title properly translatable

### DIFF
--- a/sections/Statistics.class.php
+++ b/sections/Statistics.class.php
@@ -14,7 +14,7 @@ class Statistics {
 
 		return array(
 			array(
-				"title" => "$brand ". _("Statistics"),
+				"title" => sprintf(_("%s Statistics"),$brand),
 				"group" => _("Statistics"),
 				"width" => "550px",
 				"order" => isset($order['statistics']) ? $order['statistics'] : '300',


### PR DESCRIPTION
Hi!

It is not currently possible to properly translate the dashboard statistics title because the brand name is concatenated to a translatable string with no possibility of changing the order in which these are concatenated.

While the English word order currently imposed might work for some languages it doesn't work for others.

To be properly translatable the translatable string must contain a placeholder which is replaced by the brand name and it is up to the translator to put this placeholder at the right place.

Thank you and have a nice day!

Nicolas