### PR TITLE
Rename Error class to work in PHP7

### DIFF
--- a/classes/phpsysinfo/includes/autoloader.inc.php
+++ b/classes/phpsysinfo/includes/autoloader.inc.php
@@ -48,7 +48,7 @@ function psi_autoloader($class_name) {
 		}
 	}
 
-	$error = Error::singleton();
+	$error = PSIError::singleton();
 
 	$error->addError("_autoload(\"".$class_name."\")", "autoloading of class file (class.".$class_name.".inc.php) failed!");
 	$error->errorsAsXML();
@@ -66,7 +66,7 @@ function psi_autoloader($class_name) {
  */
 function errorHandlerPsi($level, $message, $file, $line)
 {
-	$error = Error::singleton();
+	$error = PSIError::singleton();
 	$error->addPhpError("errorHandlerPsi : ", "Level : ".$level." Message : ".$message." File : ".$file." Line : ".$line);
 }
 

--- a/classes/phpsysinfo/includes/class.CommonFunctions.inc.php
+++ b/classes/phpsysinfo/includes/class.CommonFunctions.inc.php
@@ -190,7 +190,7 @@ class CommonFunctions
         $strError = '';
         $pipes = array();
         $strProgram = self::_findProgram($strProgramname);
-        $error = Error::singleton();
+        $error = PSIError::singleton();
         if (!$strProgram) {
             if ($booErrorRep) {
                 $error->addError('find_program('.$strProgramname.')', 'program not found on the machine');
@@ -280,7 +280,7 @@ class CommonFunctions
 
         $strFile = "";
         $intCurLine = 1;
-        $error = Error::singleton();
+        $error = PSIError::singleton();
         if (file_exists($strFileName)) {
             if (is_readable($strFileName)) {
                 if ($fd = fopen($strFileName, 'r')) {
@@ -358,7 +358,7 @@ class CommonFunctions
     public static function gdc($strPath, $booErrorRep = true)
     {
         $arrDirectoryContent = array();
-        $error = Error::singleton();
+        $error = PSIError::singleton();
         if (is_dir($strPath)) {
             if ($handle = opendir($strPath)) {
                 while (($strFile = readdir($handle)) !== false) {

--- a/classes/phpsysinfo/includes/error/class.PSIError.inc.php
+++ b/classes/phpsysinfo/includes/error/class.PSIError.inc.php
@@ -23,7 +23,7 @@
  * @version   Release: 3.0
  * @link      http://phpsysinfo.sourceforge.net
  */
-class Error
+class PSIError
 {
     /**
      * holds the instance of this class

--- a/classes/phpsysinfo/includes/mb/class.sensors.inc.php
+++ b/classes/phpsysinfo/includes/mb/class.sensors.inc.php
@@ -44,7 +44,7 @@ abstract class Sensors implements PSI_Interface_Sensor
      */
     public function __construct()
     {
-        $this->error = Error::singleton();
+        $this->error = PSIError::singleton();
         $this->mbinfo = new MBInfo();
     }
 

--- a/classes/phpsysinfo/includes/os/class.OS.inc.php
+++ b/classes/phpsysinfo/includes/os/class.OS.inc.php
@@ -42,7 +42,7 @@ abstract class OS implements PSI_Interface_OS
      */
     public function __construct()
     {
-        $this->error = Error::singleton();
+        $this->error = PSIError::singleton();
         $this->sys = new System();
     }
 

--- a/classes/phpsysinfo/includes/output/class.Output.inc.php
+++ b/classes/phpsysinfo/includes/output/class.Output.inc.php
@@ -37,10 +37,10 @@ abstract class Output
      */
     public function __construct()
     {
-        $this->error = Error::singleton();
+        $this->error = PSIError::singleton();
         $this->_checkConfig();
         CommonFunctions::checkForExtensions();
-//        $this->error = Error::singleton();
+//        $this->error = PSIError::singleton();
 //        $this->_checkConfig();
     }
 

--- a/classes/phpsysinfo/includes/plugin/class.PSI_Plugin.inc.php
+++ b/classes/phpsysinfo/includes/plugin/class.PSI_Plugin.inc.php
@@ -68,7 +68,7 @@ abstract class PSI_Plugin implements PSI_Interface_Plugin
      */
     public function __construct($plugin_name, $enc)
     {
-        $this->global_error = Error::Singleton();
+        $this->global_error = PSIError::Singleton();
         if (trim($plugin_name) != "") {
             $this->_plugin_name = $plugin_name;
             $this->_plugin_base = APP_ROOT."/plugins/".strtolower($this->_plugin_name)."/";

--- a/classes/phpsysinfo/includes/ups/class.ups.inc.php
+++ b/classes/phpsysinfo/includes/ups/class.ups.inc.php
@@ -44,7 +44,7 @@ abstract class UPS implements PSI_Interface_UPS
      */
     public function __construct()
     {
-        $this->error = Error::singleton();
+        $this->error = PSIError::singleton();
         $this->upsinfo = new UPSInfo();
     }
 

--- a/classes/phpsysinfo/includes/xml/class.XML.inc.php
+++ b/classes/phpsysinfo/includes/xml/class.XML.inc.php
@@ -92,7 +92,7 @@ class XML
      */
     public function __construct($complete = false, $pluginname = "")
     {
-        $this->_errors = Error::singleton();
+        $this->_errors = PSIError::singleton();
         if ($pluginname == "") {
             $this->_plugin_request = false;
             $this->_plugin = '';


### PR DESCRIPTION
Related to FREEPBX-12335 fix class conflictions with PSI
And basically a cherry pick of
https://github.com/FreePBX/dashboard/commit/3a0fc6652d26ffd890d62fb0c6fd9e3e7d2da4ee
backported to 13.0